### PR TITLE
解决一个if语句的逻辑错误和一个段错误

### DIFF
--- a/base/files/file_path.cc
+++ b/base/files/file_path.cc
@@ -207,6 +207,22 @@ bool FilePath::ReferencesParent() const {
   return false;
 }
 
+bool FilePath::IsAbsolute() const {
+  if (path_.empty())
+    return false;
+
+  // If there is a drive letter, it's an absolute path.
+  if (FindDriveLetter(path_) != StringType::npos)
+    return true;
+
+  // Starts with a separator, it's an absolute path.
+  if (IsSeparator(path_[0]))
+    return true;
+
+  // Otherwise, it's a relative path.
+  return false;
+}
+
 
 void FilePath::StripTrailingSeparatorsInternal() {
   // If there is no drive letter, start will be 1, which will prevent stripping

--- a/base/files/file_path.h
+++ b/base/files/file_path.h
@@ -112,6 +112,9 @@ class FilePath {
   // directory (e.g. has a path component that is "..").
   bool ReferencesParent() const;
 
+  // Returns true if this FilePath contains an attempt to reference the root
+  bool IsAbsolute() const;
+
  private:
   // Remove trailing separators from this object.  If the path is absolute, it
   // will never be stripped any more than to refer to the absolute root

--- a/gquiche/quic/tools/quic_server_bin.cc
+++ b/gquiche/quic/tools/quic_server_bin.cc
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
   const char* usage = "Usage: quic_server [options]";
   std::vector<std::string> non_option_args =
       quiche::QuicheParseCommandLineFlags(usage, argc, argv);
-  if (!non_option_args.empty()) {
+  if (non_option_args.empty()) {
     quiche::QuichePrintCommandLineFlagHelp(usage);
     exit(0);
   }

--- a/platform/quic_platform_impl/quic_default_proof_providers_impl.cc
+++ b/platform/quic_platform_impl/quic_default_proof_providers_impl.cc
@@ -28,6 +28,11 @@ std::unique_ptr<ProofSource> CreateDefaultProofSourceImpl() {
   const base::FilePath cert_path = base::FilePath(GetQuicFlag(FLAGS_certificate_file));
   const base::FilePath key_path  = base::FilePath(GetQuicFlag(FLAGS_key_file));
 
+  if (!cert_path.IsAbsolute() || !key_path.IsAbsolute()) {
+    QUIC_DLOG(FATAL) << "Certificate and key paths must be absolute.";
+    return nullptr;
+  }
+
   // Initialize OpenSSL if it isn't already initialized. This must be called
   // before any other OpenSSL functions though it is safe and cheap to call this
   // multiple times.


### PR DESCRIPTION
#25 

# IF语句逻辑错误

simple_quic_server在判断命令行参数是否为空的if语句中，错误地添加`!`导致逻辑错误。


# 段错误

当simple_quic_server的命令行参数中的文件名为相对路径时，fopen函数调用失败，导致ProofSource初始化失败，进一步导致段错误。